### PR TITLE
Minor bug fix: set correct B direction

### DIFF
--- a/integral.cpp
+++ b/integral.cpp
@@ -414,8 +414,8 @@ void readSOCIntegrals(oneInt &I1, int norbs, string fileprefix, schedule& schd) 
     if (schd.Bdirection.size() != 0 ) {
       double ge = 2.002319304;
       double xval = ge * schd.Bvalue * schd.Bdirection[0];
-      double yval = ge * schd.Bvalue * schd.Bdirection[0];
-      double zval = ge * schd.Bvalue * schd.Bdirection[0];
+      double yval = ge * schd.Bvalue * schd.Bdirection[1];
+      double zval = ge * schd.Bvalue * schd.Bdirection[2];
       for (int i=0; i<norbs/2; i++) {
         I1(2*i,2*i+1) += std::complex<double>(xval, -yval);
         I1(2*i+1,2*i) += std::complex<double>(xval, yval);


### PR DESCRIPTION
Hello, I use Dice to generate trial wavefunctions for AFQMC and I noticed a minor bug. Using the input keyword: "apply B 0.001 0 0 1" does not effect the SHCI energy. It seems that this is because the B-field is set to (Bx,Bx,Bx) instead of (Bx,By,Bz) due to a minor typo. I fixed the typo, and wanted to push the update upstream.