### PR TITLE
Fix incorrect parsing of FCIDUMP with complex-valued integrals

### DIFF
--- a/ZSHCI/integral.cpp
+++ b/ZSHCI/integral.cpp
@@ -215,12 +215,10 @@ void readIntegrals(string fcidump, twoInt &I2, oneInt &I1, int &nelec,
       std::getline(dump, msg);
       trim(msg);
       boost::split(tok, msg, is_any_of(", \t()"), token_compress_on);
-      //if (tok.size() != 5) continue;
-      if (tok.size() != 7) continue;
-
-      //double integral = atof(tok[0].c_str());int a=atoi(tok[1].c_str()), b=atoi(tok[2].c_str()), c=atoi(tok[3].c_str()), d=atoi(tok[4].c_str());
-      CItype integral = std::complex<double>(atof(tok[1].c_str()), atof(tok[2].c_str())); 
-      int a=atoi(tok[3].c_str()), b=atoi(tok[4].c_str()), c=atoi(tok[5].c_str()), d=atoi(tok[6].c_str());
+      if (tok.size() != 6) continue;
+      
+      CItype integral = std::complex<double>(atof(tok[0].c_str()), atof(tok[1].c_str())); 
+      int a=atoi(tok[2].c_str()), b=atoi(tok[3].c_str()), c=atoi(tok[4].c_str()), d=atoi(tok[5].c_str());
       if(a==b && b==c && c==d && d==0)
         coreE = integral.real();
       else if (b==c && c==d && d==0)


### PR DESCRIPTION
The FCIDUMP format with complex-valued integrals should have format:

```
  V_real V_imag a b c d
```

and 

```c++
boost::split(tok, msg, is_any_of(", \t()"), token_compress_on);
```
should split each line into 6 tokens, not 7, unless some unexpected whitespace character is included before V_real.