### PR TITLE
Integrals were not transformed to MO basis when provided manually

### DIFF
--- a/scripts/QMCUtils.py
+++ b/scripts/QMCUtils.py
@@ -1066,6 +1066,10 @@ def run_afqmc_mf(mf,
                   chol[i, m, n] = chol0[i, triind]
                   chol[i, n, m] = chol0[i, triind]
 
+      h1e = mo_coeff.T @ h1e @ mo_coeff
+      for gamma in range(nchol):
+          chol[gamma] = mo_coeff.T @ chol[gamma] @ mo_coeff
+
     else:
       h1e, chol, nelec, enuc = generate_integrals(mol, mf.get_hcore(), mo_coeff, chol_cut)
       nbasis = h1e.shape[-1]
@@ -1253,6 +1257,10 @@ def run_afqmc_mc(mc,
                   triind = m * (m + 1) // 2 + n
                   chol[i, m, n] = chol0[i, triind]
                   chol[i, n, m] = chol0[i, triind]
+
+      h1e = mo_coeff.T @ h1e @ mo_coeff
+      for gamma in range(nchol):
+          chol[gamma] = mo_coeff.T @ chol[gamma] @ mo_coeff
 
     else:
       h1e, chol, nelec, enuc = generate_integrals(mol, mc.get_hcore(), mo_coeff, chol_cut)


### PR DESCRIPTION
The integrals/Cholesky vectors are by default transformed into the MO basis (e.g., the alpha basis for a UHF trial). However, when integrals are instead provided, the integrals/Cholesky vectors are not transformed into the MO basis. Ref. discussion with @ankit76, this seems to have been fixed in ad-afqmc but not in Dice.