### PR TITLE
Improve rdm load save

### DIFF
--- a/SHCI/SHCI.cpp
+++ b/SHCI/SHCI.cpp
@@ -444,7 +444,7 @@ int main(int argc, char* argv[]) {
     }
     fclose(f);
   }
-  
+
   if (commrank == 0) {
     if (schd.printAllDeterminants) {
       pout << "Printing all determinants"<<endl;
@@ -519,7 +519,7 @@ int main(int argc, char* argv[]) {
 //      prevci(i,0) = prevci(i,0)*abs(maxC)/maxC;
 //  }
 //#endif
-  
+
   // #####################################################################
   // Print the 5 most important determinants and their weights
   // #####################################################################
@@ -550,7 +550,7 @@ int main(int argc, char* argv[]) {
     }
   }  // end root
   pout << std::flush;
- 
+
 
   // #####################################################################
   // RDMs
@@ -618,7 +618,7 @@ int main(int argc, char* argv[]) {
     s3RDM.setZero(norbs * norbs * norbs / 8, norbs * norbs * norbs / 8);
     SHCIrdm::Evaluate3RDM(SHMDets, DetsSize, ciroot, ciroot, nelec, schd, 0,
                           threeRDM, s3RDM);
-    SHCIrdm::save3RDM(schd, threeRDM, s3RDM, 0, norbs);
+    SHCIrdm::save3RDM(schd, threeRDM, s3RDM, 0, norbs, "variational");
   }
 
   // 4RDM
@@ -635,7 +635,7 @@ int main(int argc, char* argv[]) {
                   norbs * norbs * norbs * norbs / 16);
     SHCIrdm::Evaluate4RDM(SHMDets, DetsSize, ciroot, ciroot, nelec, schd, 0,
                           fourRDM, s4RDM);
-    SHCIrdm::save4RDM(schd, fourRDM, s4RDM, 0, norbs);
+    SHCIrdm::save4RDM(schd, fourRDM, s4RDM, 0, norbs, "variational");
   }
 
   // #####################################################################
@@ -795,9 +795,9 @@ root1, Heff(root1,root1), Heff(root2, root2), Heff(root1, root2), spinRDM);
 
     if (commrank == 0) {
       MatrixXx s2RDMdisk, twoRDMdisk;
-      SHCIrdm::loadRDM(schd, s2RDMdisk, twoRDMdisk, 0);
+      SHCIrdm::loadRDM(schd, s2RDMdisk, twoRDMdisk, 0, 0, "variational");
       s2RDMdisk = s2RDMdisk + s2RDM.adjoint() + s2RDM;
-      SHCIrdm::saveRDM(schd, s2RDMdisk, twoRDMdisk, 0, 0);
+      SHCIrdm::saveRDM(schd, s2RDMdisk, twoRDMdisk, 0, 0, "perturbative");
     }
 
     // pout << " response ";

--- a/SHCI/SHCIbasics.cpp
+++ b/SHCI/SHCIbasics.cpp
@@ -671,7 +671,7 @@ double SHCIbasics::DoPerturbativeDeterministic(
   if (schd.doResponse || schd.DoRDM) {  // build RHS for the lambda equation
     pout << endl << "Now calculating PT RDM" << endl;
     MatrixXx s2RDM, twoRDM;
-    SHCIrdm::loadRDM(schd, s2RDM, twoRDM, root);
+    SHCIrdm::loadRDM(schd, s2RDM, twoRDM, root, root, "variational");
 #ifndef SERIAL
     mpi::broadcast(world, s2RDM, 0);
     if (schd.DoSpinRDM) mpi::broadcast(world, twoRDM, 0);
@@ -687,7 +687,7 @@ double SHCIbasics::DoPerturbativeDeterministic(
         root, Psi1Norm, s2RDM, twoRDM);
     // SHCIrdm::ComputeEnergyFromSpatialRDM(norbs/2, nelec, I1, I2, coreE,
     // s2RDM);
-    SHCIrdm::saveRDM(schd, s2RDM, twoRDM, root, root);
+    SHCIrdm::saveRDM(schd, s2RDM, twoRDM, root, root, "perturbative");
 
     if (schd.RdmType == RELAXED) {
       // construct the vector Via x da
@@ -1245,7 +1245,7 @@ vector<double> SHCIbasics::DoVariational(vector<MatrixXx> &ci,
           SHCIrdm::EvaluateOneRDM(sparseHam.connections, SHMDets, DetsSize,
                                   SHMci, SHMci, sparseHam.orbDifference, nelec,
                                   schd, i, oneRDM, s1RDM);
-          SHCIrdm::save1RDM(schd, s1RDM, oneRDM, i, i);
+          SHCIrdm::save1RDM(schd, s1RDM, oneRDM, i, i, "variational");
         }
       }
 
@@ -1288,7 +1288,7 @@ vector<double> SHCIbasics::DoVariational(vector<MatrixXx> &ci,
             // if (schd.outputlevel>0)
             SHCIrdm::ComputeEnergyFromSpatialRDM(norbs / 2, nelec, I1, I2,
                                                  coreEbkp, s2RDM);
-            SHCIrdm::saveRDM(schd, s2RDM, twoRDM, i, i);
+            SHCIrdm::saveRDM(schd, s2RDM, twoRDM, i, i, "variational");
 
           } else {
             if (schd.DoTransitionRDM) {
@@ -1307,12 +1307,12 @@ vector<double> SHCIbasics::DoVariational(vector<MatrixXx> &ci,
                 SHCIrdm::EvaluateOneRDM(sparseHam.connections, SHMDets, DetsSize,
                                         SHMci, SHMci_j, sparseHam.orbDifference, nelec,
                                         schd, i, oneRDM, s1RDM);
-                SHCIrdm::save1RDM(schd, s1RDM, oneRDM, i, j);
+                SHCIrdm::save1RDM(schd, s1RDM, oneRDM, i, j, "variational");
 
                           // if (schd.outputlevel>0)
                 SHCIrdm::ComputeEnergyFromSpatialRDM(norbs / 2, nelec, I1, I2,
                                                     coreEbkp, s2RDM);
-                SHCIrdm::saveRDM(schd, s2RDM, twoRDM, i, j);
+                SHCIrdm::saveRDM(schd, s2RDM, twoRDM, i, j, "variational");
 
                 boost::interprocess::shared_memory_object::remove(
                     shciDetsCI2.c_str());
@@ -1325,14 +1325,14 @@ vector<double> SHCIbasics::DoVariational(vector<MatrixXx> &ci,
             // if (schd.outputlevel>0)
             SHCIrdm::ComputeEnergyFromSpatialRDM(norbs / 2, nelec, I1, I2,
                                                  coreEbkp, s2RDM);
-            SHCIrdm::saveRDM(schd, s2RDM, twoRDM, i, i);
+            SHCIrdm::saveRDM(schd, s2RDM, twoRDM, i, i, "variational");
 
             MatrixXx oneRDM = MatrixXx::Zero(norbs, norbs);
             MatrixXx s1RDM = MatrixXx::Zero(norbs / 2, norbs / 2);
             SHCIrdm::EvaluateOneRDM(sparseHam.connections, SHMDets, DetsSize,
                                     SHMci, SHMci, sparseHam.orbDifference, nelec,
                                     schd, i, oneRDM, s1RDM);
-            SHCIrdm::save1RDM(schd, s1RDM, oneRDM, i, i);
+            SHCIrdm::save1RDM(schd, s1RDM, oneRDM, i, i, "variational");
 
             boost::interprocess::shared_memory_object::remove(
                 shciDetsCI.c_str());

--- a/SHCI/SHCIrdm.cpp
+++ b/SHCI/SHCIrdm.cpp
@@ -354,7 +354,7 @@ void SHCIrdm::makeRDM(int *&AlphaMajorToBetaLen,
 
 //=============================================================================
 void SHCIrdm::save1RDM(schedule &schd, MatrixXx &s1RDM, MatrixXx &oneRDM,
-                       int root1, int root2) {
+                       int root1, int root2, const std::string &step) {
   /*!
 
     Writes the spatial 1RDM to text.
@@ -367,8 +367,11 @@ void SHCIrdm::save1RDM(schedule &schd, MatrixXx &s1RDM, MatrixXx &oneRDM,
             Spatial 1RDM.
         MatrixXx& oneRDM:
             Spin 1RDM.
-        int root:
-            Index of wavefunction to save.
+        int root1:
+            Index of wavefunction used to compute the RDM.
+        int root2:
+            Index of wavefunction used to compute the RDM, root2 is different
+            from root1 if saving transition RDMs.
   */
 
   int nSpatOrbs = s1RDM.rows();
@@ -376,8 +379,8 @@ void SHCIrdm::save1RDM(schedule &schd, MatrixXx &s1RDM, MatrixXx &oneRDM,
 
   if (commrank == 0) {
     char file[5000];
-    sprintf(file, "%s/spatial1RDM.%d.%d.txt", schd.prefix[0].c_str(), root1,
-            root2);
+    sprintf(file, "%s/spatial1RDM.%d.%d.%s.txt", schd.prefix[0].c_str(), root1,
+            root2, step.c_str());
     std::ofstream ofs(file, std::ios::out);
     ofs << nSpatOrbs << endl;
 
@@ -393,8 +396,8 @@ void SHCIrdm::save1RDM(schedule &schd, MatrixXx &s1RDM, MatrixXx &oneRDM,
 
     if (schd.DoSpinOneRDM) {
       char file2[5000];
-      sprintf(file2, "%s/spin1RDM.%d.%d.txt", schd.prefix[0].c_str(), root1,
-              root2);
+      sprintf(file2, "%s/spin1RDM.%d.%d.%s.txt", schd.prefix[0].c_str(), root1,
+              root2, step.c_str());
       std::ofstream ofs2(file2, std::ios::out);
       ofs2 << norbs << endl;
 
@@ -413,7 +416,7 @@ void SHCIrdm::save1RDM(schedule &schd, MatrixXx &s1RDM, MatrixXx &oneRDM,
 
 //=============================================================================
 void SHCIrdm::loadRDM(schedule &schd, MatrixXx &s2RDM, MatrixXx &twoRDM,
-                      int root) {
+                      int root1, int root2, const std::string &step) {
   /*!
 
   Loads the spatial 2RDM and the spinRDM (if the DoSpinRDM keyword was used).
@@ -428,6 +431,8 @@ void SHCIrdm::loadRDM(schedule &schd, MatrixXx &s2RDM, MatrixXx &twoRDM,
           Spin 2RDM, *changed in this function*.
       int root:
           Index of wavefunction to load.
+      string& step:
+          Step of the calculation, of the corresponding RDMs to load.
 
   */
   int norbs = twoRDM.rows();
@@ -436,8 +441,11 @@ void SHCIrdm::loadRDM(schedule &schd, MatrixXx &s2RDM, MatrixXx &twoRDM,
   if (schd.DoSpinRDM) {
     if (commrank == 0) {
       char file[5000];
-      sprintf(file, "%s/%d-spinRDM.bkp", schd.prefix[0].c_str(), root);
+      sprintf(file, "%s/%d-%d-spinRDM-%s.bkp", schd.prefix[0].c_str(), root1, root2, step.c_str());
       std::ifstream ifs(file, std::ios::binary);
+      if (!ifs) {
+        throw std::runtime_error("Error opening file: " + std::string(file));
+      }
       boost::archive::binary_iarchive load(ifs);
       load >> twoRDM;
       // ComputeEnergyFromSpinRDM(norbs, nelec, I1, I2, coreE, twoRDM);
@@ -448,8 +456,11 @@ void SHCIrdm::loadRDM(schedule &schd, MatrixXx &s2RDM, MatrixXx &twoRDM,
 
   if (commrank == 0) {
     char file[5000];
-    sprintf(file, "%s/%d-spatialRDM.bkp", schd.prefix[0].c_str(), root);
+    sprintf(file, "%s/%d-%d-spatialRDM-%s.bkp", schd.prefix[0].c_str(), root1, root2, step.c_str());
     std::ifstream ifs(file, std::ios::binary);
+    if (!ifs) {
+      throw std::runtime_error("Error opening file: " + std::string(file));
+    }
     boost::archive::binary_iarchive load(ifs);
     load >> s2RDM;
     // ComputeEnergyFromSpatialRDM(nSpatOrbs, nelec, I1, I2, coreE, s2RDM);
@@ -458,15 +469,18 @@ void SHCIrdm::loadRDM(schedule &schd, MatrixXx &s2RDM, MatrixXx &twoRDM,
   }
 }
 
-void SHCIrdm::load3RDM(schedule &schd, MatrixXx &s3RDM, int root) {
+void SHCIrdm::load3RDM(schedule &schd, MatrixXx &s3RDM, int root, const std::string &step) {
   // TODO 3RDM is currently only for the spatial 3RDM not spin.
   int nSpatOrbs = pow(s3RDM.rows(), 1 / 3);
   int nSpatOrbs2 = nSpatOrbs * nSpatOrbs;
 
   if (commrank == 0) {
     char file[5000];
-    sprintf(file, "%s/%d-spatial3RDM.bkp", schd.prefix[0].c_str(), root);
+    sprintf(file, "%s/%d-spatial3RDM-%s.bkp", schd.prefix[0].c_str(), root, step.c_str());
     std::ifstream ifs(file, std::ios::binary);
+    if (!ifs) {
+      throw std::runtime_error("Error opening file: " + std::string(file));
+    }
     boost::archive::binary_iarchive load(ifs);
     load >> s3RDM;
   } else {
@@ -476,11 +490,13 @@ void SHCIrdm::load3RDM(schedule &schd, MatrixXx &s3RDM, int root) {
 
 //=============================================================================
 void SHCIrdm::saveRDM(schedule &schd, MatrixXx &s2RDM, MatrixXx &twoRDM,
-                      int root1, int root2) {
+                      int root1, int root2, const std::string &step) {
   /*!
   Saves the spatial 2RDM and the spinRDM (if the DoSpinRDM keyword was used).
-  The spatial RDM is saves as "%s/spatialRDM.%d.%d.txt" where %s is the user
-  determined prefix and %d is the root.
+  The spatial RDM is saves as "%s/spatialRDM.%d.%d-%s.txt" where first %s is
+  the user the two %d are the root1 and root2 indices (root1 and root2 are
+  different if saving transition RDMs), and %s is the step of the calculation
+  (e.g. "variational", "perturbative", etc.).
 
   :Arguments:
 
@@ -490,16 +506,19 @@ void SHCIrdm::saveRDM(schedule &schd, MatrixXx &s2RDM, MatrixXx &twoRDM,
           Spatial 2RDM.
       MatrixXx& twoRDM:
           Spin 2RDM.
-      int root:
+      int root1:
           Index of wavefunction to save.
+      int root2:
+          Index of wavefunction to save. Different from root1 if saving
+          transition RDMs.
 
   */
   int nSpatOrbs = pow(s2RDM.rows(), 0.5);
   if (commrank == 0) {
     {
       char file[5000];
-      sprintf(file, "%s/spatialRDM.%d.%d.txt", schd.prefix[0].c_str(), root1,
-              root2);
+      sprintf(file, "%s/spatialRDM.%d.%d.%s.txt", schd.prefix[0].c_str(), root1,
+              root2, step.c_str());
       std::ofstream ofs(file, std::ios::out);
       ofs << nSpatOrbs << endl;
       for (int n1 = 0; n1 < nSpatOrbs; n1++)
@@ -514,12 +533,13 @@ void SHCIrdm::saveRDM(schedule &schd, MatrixXx &s2RDM, MatrixXx &twoRDM,
             }
       ofs.close();
     }
-    
+
     if (schd.DoSpinRDM) {
       int norbs = nSpatOrbs * 2;
       char file[5000];
-      sprintf(file, "%s/spinRDM.%d.%d.txt", schd.prefix[0].c_str(), root1,
-              root2);
+      sprintf(file, "%s/spinRDM.%d.%d.%s.txt", schd.prefix[0].c_str(), root1,
+              root2, step.c_str());
+      // Save the spinRDM in a text file
       std::ofstream ofs(file, std::ios::out);
       for (int n1 = 1; n1 < norbs; n1++)
         for (int n2 = 0; n2 < n1; n2++)
@@ -535,7 +555,7 @@ void SHCIrdm::saveRDM(schedule &schd, MatrixXx &s2RDM, MatrixXx &twoRDM,
 
     if (schd.DoSpinRDM) {
       char file[5000];
-      sprintf(file, "%s/%d-%d-spinRDM.bkp", schd.prefix[0].c_str(), root1, root2);
+      sprintf(file, "%s/%d-%d-spinRDM-%s.bkp", schd.prefix[0].c_str(), root1, root2, step.c_str());
       std::ofstream ofs(file, std::ios::binary);
       boost::archive::binary_oarchive save(ofs);
       save << twoRDM;
@@ -544,7 +564,7 @@ void SHCIrdm::saveRDM(schedule &schd, MatrixXx &s2RDM, MatrixXx &twoRDM,
 
     {
       char file[5000];
-      sprintf(file, "%s/%d-%d-spatialRDM.bkp", schd.prefix[0].c_str(), root1, root2);
+      sprintf(file, "%s/%d-%d-spatialRDM-%s.bkp", schd.prefix[0].c_str(), root1, root2, step.c_str());
       std::ofstream ofs(file, std::ios::binary);
       boost::archive::binary_oarchive save(ofs);
       save << s2RDM;
@@ -555,7 +575,7 @@ void SHCIrdm::saveRDM(schedule &schd, MatrixXx &s2RDM, MatrixXx &twoRDM,
 }
 
 void SHCIrdm::save3RDM(schedule &schd, MatrixXx &threeRDM, MatrixXx &s3RDM,
-                       int root, size_t norbs) {
+                       int root, size_t norbs, const std::string& step) {
   int nSpatOrbs = norbs / 2;  // pow(s3RDM.rows(),1/3.0);
   int nSpatOrbs2 = nSpatOrbs * nSpatOrbs;
 
@@ -615,7 +635,7 @@ void SHCIrdm::save3RDM(schedule &schd, MatrixXx &threeRDM, MatrixXx &s3RDM,
 }
 
 void SHCIrdm::save4RDM(schedule &schd, MatrixXx &fourRDM, MatrixXx &s4RDM,
-                       int root, int norbs) {
+                       int root, int norbs, const std::string& step) {
   int n = norbs / 2;
   int n2 = n * n;
   int n3 = n2 * n;

--- a/SHCI/SHCIrdm.h
+++ b/SHCI/SHCIrdm.h
@@ -51,14 +51,17 @@ void makeRDM(int*& AlphaMajorToBetaLen, vector<int*>& AlphaMajorToBeta,
              Determinant* Dets, int DetsSize, int Norbs, int nelec,
              CItype* cibra, CItype* ciket, MatrixXx& s2RDM);
 
-void save1RDM(schedule& schd, MatrixXx& s1RDM, MatrixXx& oneRDM, int root1, int root2);
-void saveRDM(schedule& schd, MatrixXx& s2RDM, MatrixXx& twoRDM, int root1, int root2);
-void loadRDM(schedule& schd, MatrixXx& s2RDM, MatrixXx& twoRDM, int root);
+void save1RDM(schedule& schd, MatrixXx& s1RDM, MatrixXx& oneRDM, int root1, int root2,
+              const std::string& step);
+void saveRDM(schedule& schd, MatrixXx& s2RDM, MatrixXx& twoRDM, int root1, int root2,
+              const std::string& step);
+void loadRDM(schedule& schd, MatrixXx& s2RDM, MatrixXx& twoRDM, int root1, int root2,
+              const std::string& step);
 void save3RDM(schedule& schd, MatrixXx& threeRDM, MatrixXx& s3RDM, int root,
-              size_t norbs);
-void save4RDM(schedule& schd, MatrixXx& fourRDM, MatrixXx& s4RDM, int root,
-              int norbs);
-void load3RDM(schedule& schd, MatrixXx& s3RDM, int root);
+              size_t norbs, const std::string& step);
+void save4RDM(schedule& schd, MatrixXx& fourRDM, MatrixXx& s4RDM, int root, int norbs,
+              const std::string& step);
+void load3RDM(schedule& schd, MatrixXx& s3RDM, int root, const std::string& step);
 
 void EvaluateRDM(vector<vector<int> >& connections, Determinant* Dets,
                  int DetsSize, CItype* cibra, CItype* ciket,


### PR DESCRIPTION
### Summary

This PR adds step-awareness to the SHCI RDM save/load functions, enabling proper handling of "variational" and "perturbative" stages in the workflow. 

### Problem

Previously:

- RDM file naming was inconsistent between the saving and loading steps.
- As a result, SHCI computations with perturbative corrections could fail to locate or load the correct RDM files.
- There was no mechanism to prevent variational RDMs from being overwritten by perturbative ones.

### Fixes Introduced

This PR modifies the RDM handling logic to:

- Add a `step` label ("variational" or "perturbative") to both saving and loading paths.
- Adopt a consistent naming scheme for RDM files in the format `prefix/root1-root2-RDMName-step.ext`, where  `step` indicates the calculation phase (e.g., `variational` or `perturbative`), and `ext` specifies the file extension (either `txt` or `bkp`).
- The workflow was updated for using these functions

### Missing
- Apply the same step-aware RDM save/load logic to the ZSHCI module.



